### PR TITLE
fixed isset problem with parent objects, used magic method __isset()

### DIFF
--- a/src/Robbo/Presenter/Presenter.php
+++ b/src/Robbo/Presenter/Presenter.php
@@ -135,4 +135,13 @@ abstract class Presenter implements \ArrayAccess {
     {
         return isset($this->object->$name);
     }
+
+    /**
+     * allow to unset parent properties
+     * @param string $name
+     */
+    public function __unset($name)
+    {
+        unset($this->object->$name);
+    }
 }


### PR DESCRIPTION
When using the service provider to automagically create Presenter instances of objects, I found there was a problem with using Form::model(), as it uses isset() to check values on the bound model. Since Presenter is just a wrapper, the values are not set. By implementing the __isset() it keeps the Form::model() working as expected. Hopefully this is an acceptable addition.
