### PR TITLE
Allow for toArray and toJson methods to work properly on a collection.

### DIFF
--- a/src/Robbo/Presenter/Presenter.php
+++ b/src/Robbo/Presenter/Presenter.php
@@ -1,6 +1,8 @@
 <?php namespace Robbo\Presenter;
 
-abstract class Presenter implements \ArrayAccess {
+use Illuminate\Support\Contracts\ArrayableInterface;
+
+abstract class Presenter implements \ArrayAccess, ArrayableInterface {
 
     /**
      * The object injected on Presenter construction.


### PR DESCRIPTION
This commit makes possible the following use case:

```
$users = User::all();

foreach ($matches as $key => $match) {
    $matches[$key] = new MatchPresenter($match);
}

return $users->toJson();
```
