### PR TITLE
Implement ArrayableInterface, JsonableInterface, JsonSerializable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0"
+        "php": ">=5.4.0",
+        "illuminate/database": "~4.2"
     },
     "require-dev": {
         "mockery/mockery": "0.7.2",

--- a/src/ObjectNotArrayException.php
+++ b/src/ObjectNotArrayException.php
@@ -1,0 +1,5 @@
+<?php namespace Robbo\Presenter;
+
+class ObjectNotArrayException extends \Exception
+{
+}

--- a/src/Presenter.php
+++ b/src/Presenter.php
@@ -248,7 +248,7 @@ abstract class Presenter implements \ArrayAccess, \JsonSerializable, ArrayableIn
         $presenterMethods = array();
 
         foreach(get_class_methods(get_called_class()) as $method) {
-            if (preg_match('/^present(.+)$/', $method, $matches)) {
+            if (preg_match(sprintf('/^%s(.+)$/', self::PRESENTER_PREFIX), $method, $matches)) {
                 $presenterMethods[] = lcfirst($matches[1]);
             }
         }
@@ -265,7 +265,9 @@ abstract class Presenter implements \ArrayAccess, \JsonSerializable, ArrayableIn
     protected function getPresentableAttributes()
     {
         foreach($this->getPresenterMethods() as $presenterMethod) {
-            $this->presentableAttributes[$presenterMethod] = call_user_func_array(array($this, self::PRESENTER_PREFIX . $presenterMethod), array());
+            $this->presentableAttributes[$presenterMethod] = call_user_func_array(
+                array($this, self::PRESENTER_PREFIX . $presenterMethod),
+                array());
         }
 
         return $this->presentableAttributes;

--- a/src/Presenter.php
+++ b/src/Presenter.php
@@ -1,6 +1,9 @@
 <?php namespace Robbo\Presenter;
 
-abstract class Presenter implements \ArrayAccess {
+use Illuminate\Support\Contracts\ArrayableInterface;
+use Illuminate\Support\Contracts\JsonableInterface;
+
+abstract class Presenter implements \ArrayAccess, \JsonSerializable, ArrayableInterface, JsonableInterface {
 
     /**
      * The object injected on Presenter construction.
@@ -8,6 +11,21 @@ abstract class Presenter implements \ArrayAccess {
      * @var mixed
      */
     protected $object;
+
+    /**
+     * Presentable funtions are prefixed with this.
+     *
+     * @const
+     */
+    const PRESENTER_PREFIX = 'present';
+
+    /**
+     * Holds the return value of our presentable methods when
+     * calling toArray or toJson.
+     *
+     * @var array
+     */
+    protected $presentableAttributes = array();
 
     /**
      * The decorator instance so we can nest presenters. Underscores here to avoid conflicts
@@ -213,10 +231,75 @@ abstract class Presenter implements \ArrayAccess {
      */
     protected function getPresenterMethodFromVariable($variable)
     {
-        $method = 'present'.str_replace(' ', '', ucwords(str_replace(['-', '_'], ' ', $variable)));
+        $method = self::PRESENTER_PREFIX . str_replace(' ', '', ucwords(str_replace(['-', '_'], ' ', $variable)));
         if (method_exists($this, $method))
         {
             return $method;
         }
+    }
+
+    /**
+     * Gets all presentable methods.
+     *
+     * @return array
+     */
+    protected function getPresenterMethods()
+    {
+        $presenterMethods = array();
+
+        foreach(get_class_methods(get_called_class()) as $method) {
+            if (preg_match('/^present(.+)$/', $method, $matches)) {
+                $presenterMethods[] = lcfirst($matches[1]);
+            }
+        }
+
+        return $presenterMethods;
+    }
+
+    /**
+     * Calls all presentable functions and returns their values paired
+     * with the function name.
+     *
+     * @return array
+     */
+    protected function getPresentableAttributes()
+    {
+        foreach($this->getPresenterMethods() as $presenterMethod) {
+            $this->presentableAttributes[$presenterMethod] = call_user_func_array(array($this, self::PRESENTER_PREFIX . $presenterMethod), array());
+        }
+
+        return $this->presentableAttributes;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toArray()
+    {
+        if ($this->object instanceof ArrayableInterface) {
+            return array_merge($this->object->toArray(), $this->getPresentableAttributes());
+        }
+
+        if (is_array($this->object)) {
+            return array_merge($this->object, $this->getPresentableAttributes());
+        }
+
+        throw new ObjectNotArrayException('Object is not compatible with ArrayableInterface or it not an array');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toJson($options = 0)
+    {
+        return json_encode($this->toArray(), $options);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function jsonSerialize()
+    {
+        return $this->toArray();
     }
 }

--- a/tests/PresenterTest.php
+++ b/tests/PresenterTest.php
@@ -112,6 +112,36 @@ class PresenterTest extends PHPUnit_Framework_TestCase {
         $this->assertFalse(isset($presenter->testVar));
     }
 
+    /**
+     * @expectedException Robbo\Presenter\ObjectNotArrayException
+     */
+    public function testInvalidObejctToArray()
+    {
+        $presenter = new PresenterStub(new InjectStub);
+        $presenter->toArray();
+    }
+
+    public function testPresenterOverridesEloquentAttribute()
+    {
+        $presenter =  new PresenterStubOverridingProperty(new InjectStubExtendsEloquentModel(array(
+            'testVar4' => 'testvar4',
+        )));
+
+        $presenterAsArray = $presenter->toArray();
+
+        $this->assertArrayHasKey('testVar4', $presenterAsArray);
+        $this->assertArrayHasKey('testNotExistingAttribute', $presenterAsArray);
+        $this->assertEquals('not testvar4', $presenterAsArray['testVar4']);
+    }
+
+    public function testPresenenterToJson()
+    {
+        $presenter =  new PresenterStubOverridingProperty(new InjectStubExtendsEloquentModel(array(
+            'testVar4' => 'testvar4',
+        )));
+
+        $this->assertJsonStringEqualsJsonFile(__DIR__ . '/expectedPresenterAsJsonString.json', $presenter->toJson());
+    }
 }
 
 class InjectStub {
@@ -146,5 +176,36 @@ class PresenterStub2 extends Presenter {
     public function testMethod3()
     {
         return 'testMethod3';
+    }
+}
+
+class InjectStubExtendsEloquentModel extends \Illuminate\Database\Eloquent\Model {
+
+    public $testVar = 'testvar';
+    public $fillable = array('testVar4');
+
+    public function testMethod()
+    {
+        return 'testMethod';
+    }
+}
+
+class PresenterStubOverridingProperty extends Presenter {
+
+    public $testVar3 = 'testvar3';
+
+    public function testMethod3()
+    {
+        return 'testMethod3';
+    }
+
+    public function presentTestVar4()
+    {
+        return 'not testvar4';
+    }
+
+    public function presentTestNotExistingAttribute()
+    {
+        return 'new attribute from presentor';
     }
 }

--- a/tests/expectedPresenterAsJsonString.json
+++ b/tests/expectedPresenterAsJsonString.json
@@ -1,0 +1,1 @@
+{"testVar4":"not testvar4","testNotExistingAttribute":"new attribute from presentor"}

--- a/tests/expectedPresenterAsJsonString.json
+++ b/tests/expectedPresenterAsJsonString.json
@@ -1,1 +1,4 @@
-{"testVar4":"not testvar4","testNotExistingAttribute":"new attribute from presentor"}
+{
+   "testVar4":"not testvar4",
+   "testNotExistingAttribute":"new attribute from presentor"
+}


### PR DESCRIPTION
This allows the presenter objects to be serialized as arrays or JSON
strings. This could be used for Eloquent models (or anything that
implements ArrayableInterface) and would allow them to be send directly
as a response, for example in a REST API.
