### PR TITLE
Updated to support Laravel 5.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ It's recommended that you use Composer, however you can download and install fro
 
 This package comes with an optional service provider for Laravel 4 so that you can automate some extra steps. You will need to have installed using the composer method above, then register the service provider with your application.
 
-Open `app/config/app.php` and find the `providers` key. Add 
+Open `app/config/app.php` and find the `providers` key. Add
 ```
 'Robbo\Presenter\PresenterServiceProvider',
-``` 
-to the array at some point after 
+```
+to the array at some point after
 ```
 'Illuminate\View\ViewServiceProvider',
 ```
@@ -64,7 +64,7 @@ Let's say you have a list of users and you want to generate a link to the profil
 ```php
 
 class UserPresenter extends Robbo\Presenter\Presenter {
-	
+
 	public function url()
 	{
 		return $this->id.'-'.$this->username;
@@ -78,7 +78,7 @@ However you might not want to be calling methods like this, it could be inconsis
 ```php
 
 class UserPresenter extends Robbo\Presenter\Presenter {
-	
+
 	public function presentUrl()
 	{
 		return $this->id.'-'.$this->username;
@@ -100,7 +100,7 @@ class User {
 }
 
 class UserPresenter extends Robbo\Presenter\Presenter {
-	
+
 	// ...
 }
 
@@ -134,12 +134,12 @@ For Example.
 ```php
 
 class UserPresenter extends Robbo\Presenter\Presenter {
-	
+
 	// ...
 }
 
 class User implements Robbo\Presenter\PresentableInterface {
-	
+
 	/**
 	 * Return a created presenter.
 	 *
@@ -169,7 +169,7 @@ $user = [
 ];
 
 class UserPresenter extends Robbo\Presenter\Presenter {
-	
+
 	public function presentUrl()
 	{
 		// This will work exactly the same as previous examples
@@ -198,8 +198,8 @@ echo 'And again: ', $user['url'];
 
 ### Extending the Decorator
 
-As of 1.2.x I have added in a decorator object. This object takes care of turning an object that has `PresentableInterface` into a `Presenter`. 
-By default, this is done with Laravel's `View` objects. The reasoning behind a new class instead of the previous implementation is so it can be better tested and also to allow you to extend it. 
+As of 1.2.x I have added in a decorator object. This object takes care of turning an object that has `PresentableInterface` into a `Presenter`.
+By default, this is done with Laravel's `View` objects. The reasoning behind a new class instead of the previous implementation is so it can be better tested and also to allow you to extend it.
 Here is an example of extending the `Decorator` so that instead of using the `PresentableInterface` and `getPresenter()` method you can use a public variable on the object called `$presenter`.
 
 Note: these instructions are for Laravel usage.
@@ -211,7 +211,7 @@ First extend the decorator...
 use Robbo\Presenter\Decorator as BaseDecorator;
 
 class Decorator extends BaseDecorator {
-	
+
 	/*
      * If this variable implements Robbo\Presenter\PresentableInterface then turn it into a presenter.
      *

--- a/src/PresenterServiceProvider.php
+++ b/src/PresenterServiceProvider.php
@@ -31,11 +31,11 @@ class PresenterServiceProvider extends ServiceProvider {
      */
     public function registerDecorator()
     {
-        $this->app['presenter.decorator'] = $this->app->share(function($app)
+        $this->app->singleton('presenter.decorator', function($app)
         {
             $decorator = new Decorator;
 
-            // This isn't really doing anything here however if you want to extend the decorator 
+            // This isn't really doing anything here however if you want to extend the decorator
             // with your own instance then you need to do it like this in your own service
             // provider or in start/global.php.
             Presenter::setExtendedDecorator($decorator);
@@ -52,7 +52,7 @@ class PresenterServiceProvider extends ServiceProvider {
      */
     public function registerFactory()
     {
-        $this->app['view'] = $this->app->share(function($app)
+        $this->app->singleton('view', function($app)
         {
             // Next we need to grab the engine resolver instance that will be used by the
             // factory. The resolver will be used by a factory to get each of


### PR DESCRIPTION
The "share" method has been deprecated, and in 5.4 now removed completely. The singleton method has existed for a long time, which does the same thing with a slightly different syntax