### PR TITLE
Refactoring Tests

### DIFF
--- a/tests/DecoratorTest.php
+++ b/tests/DecoratorTest.php
@@ -1,9 +1,10 @@
 <?php
 
 use Robbo\Presenter\Decorator;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Support\Collection;
 
-class DecoratorTest extends PHPUnit_Framework_TestCase
+class DecoratorTest extends TestCase
 {
     public function testPresentableToPresenter()
     {

--- a/tests/PresenterTest.php
+++ b/tests/PresenterTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Robbo\Presenter\Presenter;
+use PHPUnit\Framework\TestCase;
 
-class PresenterTest extends PHPUnit_Framework_TestCase
+class PresenterTest extends TestCase
 {
     public function testPresenterVariableCalls()
     {

--- a/tests/ViewFactoryTest.php
+++ b/tests/ViewFactoryTest.php
@@ -4,11 +4,12 @@ use Mockery as m;
 use Robbo\Presenter\Presenter;
 use Robbo\Presenter\Decorator;
 use Robbo\Presenter\View\View;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Support\Collection;
 use Robbo\Presenter\View\Factory;
 use Robbo\Presenter\PresentableInterface;
 
-class ViewFactoryTest extends PHPUnit_Framework_TestCase
+class ViewFactoryTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/ViewTest.php
+++ b/tests/ViewTest.php
@@ -4,9 +4,10 @@ use Mockery as m;
 use Robbo\Presenter\View\View;
 use Robbo\Presenter\Presenter;
 use Robbo\Presenter\Decorator;
+use PHPUnit\Framework\TestCase;
 use Robbo\Presenter\PresentableInterface;
 
-class ViewTest extends PHPUnit_Framework_TestCase
+class ViewTest extends TestCase
 {
     public function tearDown()
     {


### PR DESCRIPTION
I suggest use `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase`.
This will help migrate to **PHPUnit +6 version**, that no longer support "snake case" class names...